### PR TITLE
Add cache-buster querystring to asset references

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 		<title>Rudy Scoggins</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+               <link rel="stylesheet" href="assets/css/main.css?v=20250619" />
+               <noscript><link rel="stylesheet" href="assets/css/noscript.css?v=20250619" /></noscript>
 	</head>
 	<body class="is-preload">
 
@@ -176,13 +176,13 @@
 			</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrollex.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+                       <script src="assets/js/jquery.min.js?v=20250619"></script>
+                       <script src="assets/js/jquery.scrollex.min.js?v=20250619"></script>
+                       <script src="assets/js/jquery.scrolly.min.js?v=20250619"></script>
+                       <script src="assets/js/browser.min.js?v=20250619"></script>
+                       <script src="assets/js/breakpoints.min.js?v=20250619"></script>
+                       <script src="assets/js/util.js?v=20250619"></script>
+                       <script src="assets/js/main.js?v=20250619"></script>
 
 			<script>
 				document.getElementById("year").innerHTML = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- version CSS and JS includes with cache-buster querystring

## Testing
- `grep -n 'v=20250619' -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6854bf5d5af4832c81739bc6b1fbfefc