### PR TITLE
Fix staging path validation

### DIFF
--- a/transfer_songs.py
+++ b/transfer_songs.py
@@ -12,7 +12,11 @@ staging_dir = args.staging
 
 if not os.path.isdir(source_dir):
     raise SystemExit(f'Source directory {source_dir} does not exist.')
-if not os.path.isdir(staging_dir):
+
+if os.path.exists(staging_dir):
+    if not os.path.isdir(staging_dir):
+        raise SystemExit(f'Staging path {staging_dir} exists and is not a directory.')
+else:
     os.makedirs(staging_dir, exist_ok=True)
 
 for filename in os.listdir(source_dir):


### PR DESCRIPTION
## Summary
- avoid creating a directory when the staging path is an existing file

## Testing
- `python3 -m py_compile transfer_songs.py`
- `python3 transfer_songs.py /tmp/source_dir /tmp/staging_dir`
- `python3 transfer_songs.py /tmp/source_dir /tmp/tmpdir/myfile` (fails with a message)


------
https://chatgpt.com/codex/tasks/task_e_6854c45a115c832c8b5b12c9f08d5401