### PR TITLE
Add FastAPI app with no-cache middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI, Request, Response
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+
+@app.middleware("http")
+async def add_no_cache_headers(request: Request, call_next):
+    response: Response = await call_next(request)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
+# Serve static files from the repository root
+app.mount("/", StaticFiles(directory=".", html=True), name="static")
+


### PR DESCRIPTION
## Summary
- add a simple FastAPI `app.py` with middleware that sets `Cache-Control`, `Pragma`, and `Expires` headers on every response
- mount the repository root as static files so the site can be served via FastAPI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855c7e80400832cbab1c4fb51099f78